### PR TITLE
Add strongly typed way to specify allowed HTTP methods for RouteAttribute

### DIFF
--- a/src/AttributeRouting/RouteAttribute.cs
+++ b/src/AttributeRouting/RouteAttribute.cs
@@ -32,6 +32,16 @@ namespace AttributeRouting
         }
 
         /// <summary>
+        /// Specify the route information for an action.
+        /// </summary>
+        /// <param name="url">The url that is associated with this action</param>
+        /// <param name="allowedMethods">The httpMethods against which to constrain the route</param>
+        public RouteAttribute(string url, HttpVerbs allowedMethods)
+            : this(url, allowedMethods.ToString().ToUpper().SplitAndTrim(new[] { "," }))
+        {
+        }
+
+        /// <summary>
         /// The url for this action.
         /// </summary>
         public string Url { get; private set; }


### PR DESCRIPTION
Actually this changes are pretty straightforward. And this way to specify allowed HTTP verbs looks a bit nicer and more natural for me. Hope you'll like it too.

Example:

```
[Route("Home", "GET", "POST")]
// vs.
[Route("Home", HttpVerbs.Get | HttpVerbs.Post)]
```
