### PR TITLE
Identify controllers that do not inherit from Controller

### DIFF
--- a/src/AttributeRouting/AttributeRoutingConfiguration.cs
+++ b/src/AttributeRouting/AttributeRoutingConfiguration.cs
@@ -92,7 +92,7 @@ namespace AttributeRouting
         /// </summary>
         /// <typeparam name="TController">The controller type</typeparam>
         public void AddRoutesFromController<TController>()
-            where TController : Controller
+            where TController : IController
         {
             AddRoutesFromController(typeof(TController));
         }

--- a/src/AttributeRouting/Extensions/ReflectionExtensions.cs
+++ b/src/AttributeRouting/Extensions/ReflectionExtensions.cs
@@ -11,7 +11,7 @@ namespace AttributeRouting.Extensions
         public static IEnumerable<Type> GetControllerTypes(this Assembly assembly)
         {
             return from type in assembly.GetTypes()
-                   where !type.IsAbstract && typeof(Controller).IsAssignableFrom(type)
+                   where !type.IsAbstract && typeof(IController).IsAssignableFrom(type)
                    select type;
         }
 


### PR DESCRIPTION
While most controllers will inherit from Controller, it's possible that people could derive their controllers either from ControllerBase or IController. The former is the least common denominator, so this patch allows classes that can be assigned to IController to be identified and routed.
