### PR TITLE
Config setting for trailing slash on outgoing URL paths. 

### DIFF
--- a/src/AttributeRouting.Specs/Tests/AttributeRouteTests.cs
+++ b/src/AttributeRouting.Specs/Tests/AttributeRouteTests.cs
@@ -22,9 +22,19 @@ namespace AttributeRouting.Specs.Tests
         }
 
         [Test]
+        public void GetVirtualPath_does_not_append_trailing_slash_to_urls_when_not_configured_to_do_so() {
+            var route = BuildAttributeRoute("Controller/Action", false, false);
+
+            var virtualPathData = route.GetVirtualPath(_requestContextMock.Object, new RouteValueDictionary());
+
+            Assert.That(virtualPathData, Is.Not.Null);
+            Assert.That(virtualPathData.VirtualPath, Is.EqualTo(route.Url));
+        }
+
+        [Test]
         public void GetVirtualPath_does_not_lowercase_urls_when_not_configured_to_do_so()
         {
-            var route = BuildAttributeRoute("Controller/Action", false);
+            var route = BuildAttributeRoute("Controller/Action", false, false);
 
             var virtualPathData = route.GetVirtualPath(_requestContextMock.Object, new RouteValueDictionary());
 
@@ -35,7 +45,7 @@ namespace AttributeRouting.Specs.Tests
         [Test]
         public void GetVirtualPath_returns_lowercase_paths_when_configured_to_do_so()
         {
-            var route = BuildAttributeRoute("Controller/Action", true);
+            var route = BuildAttributeRoute("Controller/Action", true, false);
 
             var routeValues = new RouteValueDictionary(new { query = "MixedCase" });
             var virtualPathData = route.GetVirtualPath(_requestContextMock.Object, routeValues);
@@ -45,7 +55,19 @@ namespace AttributeRouting.Specs.Tests
                         Is.EqualTo(route.Url.ToLowerInvariant() + "?query=MixedCase"));
         }
 
-        private AttributeRoute BuildAttributeRoute(string url, bool useLowercaseRoutes)
+        [Test]
+        public void GetVirtualPath_returns_paths_with_trailing_slash_when_configured_to_do_so() {
+            var route = BuildAttributeRoute("Controller/Action", false, true);
+
+            var routeValues = new RouteValueDictionary(new { query = "MixedCase" });
+            var virtualPathData = route.GetVirtualPath(_requestContextMock.Object, routeValues);
+
+            Assert.That(virtualPathData, Is.Not.Null);
+            Assert.That(virtualPathData.VirtualPath,
+                        Is.EqualTo(route.Url + "/?query=MixedCase"));
+        }
+
+        private AttributeRoute BuildAttributeRoute(string url, bool useLowercaseRoutes, bool appendTrailingSlash)
         {
             return new AttributeRoute(null,
                                       url,
@@ -53,6 +75,7 @@ namespace AttributeRouting.Specs.Tests
                                       new RouteValueDictionary(),
                                       new RouteValueDictionary(),
                                       useLowercaseRoutes,
+                                      appendTrailingSlash,
                                       new MvcRouteHandler());
         }
     }

--- a/src/AttributeRouting/AttributeRoutingConfiguration.cs
+++ b/src/AttributeRouting/AttributeRoutingConfiguration.cs
@@ -36,6 +36,12 @@ namespace AttributeRouting
         public bool UseLowercaseRoutes { get; set; }
 
         /// <summary>
+        /// When true, the generated routes will have a trailing slash on the path of outbound URLs.
+        /// The default is false.
+        /// </summary>
+        public bool AppendTrailingSlash { get; set; }
+
+        /// <summary>
         /// When true, the generated routes will have auto-generated route names in the form controller_action.
         /// The default is false.
         /// </summary>

--- a/src/AttributeRouting/Framework/RouteBuilder.cs
+++ b/src/AttributeRouting/Framework/RouteBuilder.cs
@@ -36,6 +36,7 @@ namespace AttributeRouting.Framework
                                       CreateRouteConstraints(routeSpec),
                                       CreateRouteDataTokens(routeSpec),
                                       _configuration.UseLowercaseRoutes,
+                                      _configuration.AppendTrailingSlash,
                                       _configuration.RouteHandlerFactory.Invoke());
         }
 


### PR DESCRIPTION
Generated URLs can be configured to include a trailing slash for SEO consistency, if that is your site's preference (see [Google Webmaster Central Blog article](http://googlewebmastercentral.blogspot.com/2010/04/to-slash-or-not-to-slash.html)). I wasn't seeing a way to config this behavior already, so I slapped together a couple tests and wrote the appropriate code.

Submitted in combination with a [corresponding issue](https://github.com/mccalltd/AttributeRouting/issues/40).
