### PR TITLE
Include Actions in Base Controllers

### DIFF
--- a/src/AttributeRouting.Web/Areas/Admin/Controllers/AdminControllerBase.cs
+++ b/src/AttributeRouting.Web/Areas/Admin/Controllers/AdminControllerBase.cs
@@ -1,9 +1,10 @@
-﻿using AttributeRouting.Web.Controllers;
+﻿
+using AttributeRouting.Web.Controllers;
 
 namespace AttributeRouting.Web.Areas.Admin.Controllers
 {
     [RouteArea("Admin")]
-    public class AdminControllerBase : ControllerBase
+    public abstract class AdminControllerBase : ControllerBase
     {
     }
 }

--- a/src/AttributeRouting.Web/Controllers/ControllerBase.cs
+++ b/src/AttributeRouting.Web/Controllers/ControllerBase.cs
@@ -2,11 +2,20 @@
 
 namespace AttributeRouting.Web.Controllers
 {
-    public class ControllerBase : Controller
+    public abstract class ControllerBase : Controller
     {
         protected void Flash(string message)
         {
             TempData["flash"] = message;
+        }
+
+        [GET("BaseTestMethod")]
+        public JsonResult BaseTestMethod()
+        {
+            return Json(new
+            {
+                Test = "Hello World"
+            }, JsonRequestBehavior.AllowGet);
         }
     }
 }

--- a/src/AttributeRouting.Web/Global.asax.cs
+++ b/src/AttributeRouting.Web/Global.asax.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Web.Mvc;
 using System.Web.Routing;
 using AttributeRouting.Framework.Localization;
@@ -49,6 +48,7 @@ namespace AttributeRouting.Web
                 config.AddTranslationProvider(translationProvider);
                 config.UseRouteHandler(() => new CultureAwareRouteHandler());
                 config.UseLowercaseRoutes = true;
+                config.InheritActionsFromBaseController = true;
             });
 
             routes.MapRoute("CatchAll",

--- a/src/AttributeRouting/AttributeRoutingConfiguration.cs
+++ b/src/AttributeRouting/AttributeRoutingConfiguration.cs
@@ -19,6 +19,7 @@ namespace AttributeRouting
         /// </summary>
         public AttributeRoutingConfiguration()
         {
+            InheritActionsFromBaseController = false;
             Assemblies = new List<Assembly>();
             PromotedControllerTypes = new List<Type>();
             DefaultRouteConstraints = new Dictionary<string, IRouteConstraint>();
@@ -80,8 +81,15 @@ namespace AttributeRouting
         public string DefaultSubdomain { get; set; }
 
         /// <summary>
+        /// When true, the generated routes will include actions defined on base controllers.
+        /// The default is false
+        /// </summary>
+        public bool InheritActionsFromBaseController { get; set; }
+
+        /// <summary>
         /// Constrains translated routes by the thread's current UI culture.
         /// The default is false.
+        /// Note: Base Controllers should be declared as abstract to avoid routes being generated for them
         /// </summary>
         public bool ConstrainTranslatedRoutesByCurrentUICulture { get; set; }
 

--- a/src/AttributeRouting/Framework/RouteReflector.cs
+++ b/src/AttributeRouting/Framework/RouteReflector.cs
@@ -19,7 +19,7 @@ namespace AttributeRouting.Framework
 
         public IEnumerable<RouteSpecification> GenerateRouteSpecifications()
         {
-            var controllerRouteSpecs = GenerateRouteSpecifications(_configuration.PromotedControllerTypes);
+            var controllerRouteSpecs = GenerateRouteSpecifications(_configuration.PromotedControllerTypes, _configuration.InheritActionsFromBaseController);
             foreach (var spec in controllerRouteSpecs)
                 yield return spec;
 
@@ -29,13 +29,13 @@ namespace AttributeRouting.Framework
             var scannedControllerTypes = _configuration.Assemblies.SelectMany(a => a.GetControllerTypes()).ToList();
             var remainingControllerTypes = scannedControllerTypes.Except(_configuration.PromotedControllerTypes);
 
-            var remainingRouteSpecs = GenerateRouteSpecifications(remainingControllerTypes);
+            var remainingRouteSpecs = GenerateRouteSpecifications(remainingControllerTypes, _configuration.InheritActionsFromBaseController);
 
             foreach (var spec in remainingRouteSpecs)
                 yield return spec;
         }
 
-        private IEnumerable<RouteSpecification> GenerateRouteSpecifications(IEnumerable<Type> controllerTypes)
+        private IEnumerable<RouteSpecification> GenerateRouteSpecifications(IEnumerable<Type> controllerTypes, bool inheritActionsFromBaseController)
         {
             var controllerCount = 0;
 
@@ -44,7 +44,7 @@ namespace AttributeRouting.Framework
                     let convention = controllerType.GetCustomAttribute<RouteConventionAttribute>(false)
                     let routeAreaAttribute = controllerType.GetCustomAttribute<RouteAreaAttribute>(true)
                     let routePrefixAttribute = controllerType.GetCustomAttribute<RoutePrefixAttribute>(true)
-                    from actionMethod in controllerType.GetActionMethods()
+                    from actionMethod in controllerType.GetActionMethods(inheritActionsFromBaseController)
                     from routeAttribute in GetRouteAttributes(actionMethod, convention)
                     orderby controllerIndex, routeAttribute.Precedence
                     // precedence is within a controller

--- a/src/AttributeRouting/Helpers/ReflectionExtensions.cs
+++ b/src/AttributeRouting/Helpers/ReflectionExtensions.cs
@@ -15,9 +15,14 @@ namespace AttributeRouting.Helpers
                    select type;
         }
 
-        public static IEnumerable<MethodInfo> GetActionMethods(this Type type)
+        public static IEnumerable<MethodInfo> GetActionMethods(this Type type, bool inheritActionsFromBaseController)
         {
-            return type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            var flags = BindingFlags.Public | BindingFlags.Instance;
+
+            if (!inheritActionsFromBaseController)
+                flags |= BindingFlags.DeclaredOnly;
+
+            return type.GetMethods(flags);
         }
 
         public static IEnumerable<TAttribute> GetCustomAttributes<TAttribute>(this Type type, bool inherit)


### PR DESCRIPTION
I added a new config setting which is false by default.

When enabled it will include actions defined on the base controllers.

I updated the existing base controllers to be abstract, if base controllers are not abstract then it generates duplicate routes on the home controllers by creating routes for 'ControllerBase'

If that makes sense.
