### PR TITLE
Bug with AreaUrl when Subdomains configured by configuration object and no Subdomain set in RouteAreaAttribute

### DIFF
--- a/src/AttributeRouting.Specs/Subjects/SubdomainControllers.cs
+++ b/src/AttributeRouting.Specs/Subjects/SubdomainControllers.cs
@@ -12,6 +12,16 @@ namespace AttributeRouting.Specs.Subjects
         }
     }
 
+    [RouteArea("NoSubdomain")]
+    public class SubdomainControllerWithoutSubdomainInAttribute : Controller
+    {
+        [GET("")]
+        public ActionResult Index()
+        {
+            return Content("");
+        }
+    }
+
     [RouteArea("Admin", Subdomain = "private", AreaUrl = "admin")]
     public class SubdomainWithAreaUrlController : Controller
     {

--- a/src/AttributeRouting.Specs/Tests/Subdomains/RouteReflectorTests.cs
+++ b/src/AttributeRouting.Specs/Tests/Subdomains/RouteReflectorTests.cs
@@ -51,5 +51,22 @@ namespace AttributeRouting.Specs.Tests.Subdomains
             Assert.That(spec.AreaName, Is.EqualTo("Users"));
             Assert.That(spec.AreaUrl, Is.EqualTo(null));
         }
+
+        [Test]
+        public void Returns_null_area_url_when_controller_configured_with_subdomain_only_via_configuration_object()
+        {
+            var configuration = new AttributeRoutingConfiguration();
+            configuration.AddRoutesFromController<SubdomainControllerWithoutSubdomainInAttribute>();
+            configuration.MapArea("NoSubdomain").ToSubdomain("subdomain");
+
+            var reflector = new RouteReflector(configuration);
+            var specs = reflector.GenerateRouteSpecifications().ToList();
+
+            var spec = specs.SingleOrDefault();
+            Assert.That(spec, Is.Not.Null);
+            Assert.That(spec.Subdomain, Is.EqualTo("subdomain"));
+            Assert.That(spec.AreaName, Is.EqualTo("NoSubdomain"));
+            Assert.That(spec.AreaUrl, Is.EqualTo(null));
+        }
     }
 }

--- a/src/AttributeRouting/Framework/RouteReflector.cs
+++ b/src/AttributeRouting/Framework/RouteReflector.cs
@@ -49,12 +49,13 @@ namespace AttributeRouting.Framework
                     orderby controllerIndex, routeAttribute.Precedence
                     // precedence is within a controller
                     let routeName = routeAttribute.RouteName
+                    let subdomain = GetAreaSubdomain(routeAreaAttribute)
                     select new RouteSpecification
                     {
                         AreaName = routeAreaAttribute.SafeGet(a => a.AreaName),
-                        AreaUrl = GetAreaUrl(routeAreaAttribute),
+                        AreaUrl = GetAreaUrl(routeAreaAttribute, subdomain),
                         AreaUrlTranslationKey = routeAreaAttribute.SafeGet(a => a.TranslationKey),
-                        Subdomain = GetAreaSubdomain(routeAreaAttribute),
+                        Subdomain = subdomain,
                         RoutePrefixUrl = GetRoutePrefix(routePrefixAttribute, actionMethod, convention),
                         RoutePrefixUrlTranslationKey = routePrefixAttribute.SafeGet(a => a.TranslationKey),
                         ControllerType = controllerType,
@@ -86,16 +87,17 @@ namespace AttributeRouting.Framework
             return attributes.OrderBy(a => a.Order);
         }
 
-        private static string GetAreaUrl(RouteAreaAttribute routeAreaAttribute)
+        private static string GetAreaUrl(RouteAreaAttribute routeAreaAttribute, string subdomain)
         {
             if (routeAreaAttribute == null)
                 return null;
 
-            // If a subdomain is specified for the area, then assume the area url is blank;
+            // If a subdomain is specified for the area either in the RouteAreaAttribute or via 
+            // configuration, then assume the area url is blank;
             // eg: admin.badass.com.
             // However, our fearless coder can decide to explicitly specify an area url if desired;
             // eg: internal.badass.com/admin.
-            if (routeAreaAttribute.Subdomain.HasValue() && routeAreaAttribute.AreaUrl.HasNoValue())
+            if (subdomain.HasValue() && routeAreaAttribute.AreaUrl.HasNoValue())
                 return null;
 
             return routeAreaAttribute.AreaUrl ?? routeAreaAttribute.AreaName;


### PR DESCRIPTION
Hi!

I found an issue with the generated routes when having an area mapped to a subdomain via configuration object, but the RouteAreaAttribute didn't specify the Subdomain property.
What I think is expected here is to generate the route without the AreaUrl, but AttributeRouting is still appending the AreaUrl part in the route, so for example, having this:

```
[RouteArea("NoSubdomain")]
public class SubdomainControllerWithoutSubdomainInAttribute : Controller
{
    [GET("")]
    public ActionResult Index()
    {
        return Content("");
    }
}
```

With this configuration:

```
var configuration = new AttributeRoutingConfiguration();
configuration.AddRoutesFromController<SubdomainControllerWithoutSubdomainInAttribute>();
configuration.MapArea("NoSubdomain").ToSubdomain("subdomain");
```

I'm expecting to have this route for the Index action:

subdomain.site.com

but I'm having this route instead:

subdomain.site.com/nosubdomain

The workaround without fixing this would be to put AreaUrl = "" to the RouteAreaAttribute.

I'm attaching the fix for this bug, along with a backing test.
Let me know what you think about this bug, if you consider it as such and if the fix is correct and properly implemented.

Thanks in advance! Keep up the great job with this library!
