### PR TITLE
Removed reference to MVC2 & Test Project Type not supported by VS11

### DIFF
--- a/src/AttributeRouting.Tests.Web/AttributeRouting.Tests.Web.csproj
+++ b/src/AttributeRouting.Tests.Web/AttributeRouting.Tests.Web.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,7 +8,7 @@
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{486087C6-E95B-4FE2-8263-7B6B2DF81888}</ProjectGuid>
-    <ProjectTypeGuids>{F85E285D-A4E0-4152-9332-AB1D724D3325};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AttributeRouting.Tests.Web</RootNamespace>
@@ -25,6 +26,15 @@
     <UseIISExpress>true</UseIISExpress>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>4.0</OldToolsVersion>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -89,7 +99,7 @@
       <Private>True</Private>
       <HintPath>..\packages\AspNetWebApi.4.0.20126.16343\lib\net40\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Mvc, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
@@ -204,8 +214,13 @@
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
+++ b/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
@@ -41,7 +41,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
-    <Reference Include="System.Web.Mvc, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/AttributeRouting.sln
+++ b/src/AttributeRouting.sln
@@ -1,31 +1,13 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting", "AttributeRouting\AttributeRouting.csproj", "{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Specs", "AttributeRouting.Specs\AttributeRouting.Specs.csproj", "{E832A82B-2302-4113-83E3-261446E22C87}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Tests.Web", "AttributeRouting.Tests.Web\AttributeRouting.Tests.Web.csproj", "{486087C6-E95B-4FE2-8263-7B6B2DF81888}"
-EndProject
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 11
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{38404E6F-56AC-458E-B0A6-3620FEA10A5C}"
 	ProjectSection(SolutionItems) = preProject
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http.WebHost", "AttributeRouting.Web.Http.WebHost\AttributeRouting.Web.Http.WebHost.csproj", "{A018FEC5-45F8-44FB-BB6C-33697B418434}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web", "AttributeRouting.Web\AttributeRouting.Web.csproj", "{C91C065B-A821-4890-9F31-F9E245D804D1}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{840281A8-8870-417F-9B24-ED0E866608A2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Mvc", "AttributeRouting.Web.Mvc\AttributeRouting.Web.Mvc.csproj", "{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http.SelfHost", "AttributeRouting.Web.Http.SelfHost\AttributeRouting.Web.Http.SelfHost.csproj", "{246F7AEC-9429-4FBB-8747-92A3F025C711}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Tests.SelfHost", "AttributeRouting.Tests.SelfHost\AttributeRouting.Tests.SelfHost.csproj", "{0D2A13E6-A092-402E-B8FE-035F3A620B86}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http", "AttributeRouting.Web.Http\AttributeRouting.Web.Http.csproj", "{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{DE34F753-6251-493F-902B-D520D655F69A}"
 	ProjectSection(SolutionItems) = preProject
@@ -39,10 +21,28 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{01EC4F0A
 		..\build.xml = ..\build.xml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting", "AttributeRouting\AttributeRouting.csproj", "{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Specs", "AttributeRouting.Specs\AttributeRouting.Specs.csproj", "{E832A82B-2302-4113-83E3-261446E22C87}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Tests.Web", "AttributeRouting.Tests.Web\AttributeRouting.Tests.Web.csproj", "{486087C6-E95B-4FE2-8263-7B6B2DF81888}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http.WebHost", "AttributeRouting.Web.Http.WebHost\AttributeRouting.Web.Http.WebHost.csproj", "{A018FEC5-45F8-44FB-BB6C-33697B418434}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web", "AttributeRouting.Web\AttributeRouting.Web.csproj", "{C91C065B-A821-4890-9F31-F9E245D804D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Mvc", "AttributeRouting.Web.Mvc\AttributeRouting.Web.Mvc.csproj", "{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http.SelfHost", "AttributeRouting.Web.Http.SelfHost\AttributeRouting.Web.Http.SelfHost.csproj", "{246F7AEC-9429-4FBB-8747-92A3F025C711}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Tests.SelfHost", "AttributeRouting.Tests.SelfHost\AttributeRouting.Tests.SelfHost.csproj", "{0D2A13E6-A092-402E-B8FE-035F3A620B86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AttributeRouting.Web.Http", "AttributeRouting.Web.Http\AttributeRouting.Web.Http.csproj", "{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}"
+EndProject
 Global
 	GlobalSection(SubversionScc) = preSolution
-		Svn-Managed = True
 		Manager = AnkhSVN - Subversion Support for Visual Studio
+		Svn-Managed = True
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,26 +53,36 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|x86.ActiveCfg = Release|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{E832A82B-2302-4113-83E3-261446E22C87}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Mixed Platforms.Build.0 = Debug|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|x86.ActiveCfg = Debug|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|x86.Build.0 = Debug|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Any CPU.ActiveCfg = Release|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Mixed Platforms.ActiveCfg = Release|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Mixed Platforms.Build.0 = Release|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|x86.ActiveCfg = Release|x86
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|x86.Build.0 = Release|x86
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Any CPU.Build.0 = Release|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|x86.ActiveCfg = Release|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|x86.ActiveCfg = Release|Any CPU
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -83,6 +93,16 @@ Global
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888}.Release|x86.ActiveCfg = Release|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{871A79CF-C705-4C6B-8938-F9AA1E02AEA4}.Release|x86.ActiveCfg = Release|Any CPU
 		{A018FEC5-45F8-44FB-BB6C-33697B418434}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A018FEC5-45F8-44FB-BB6C-33697B418434}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A018FEC5-45F8-44FB-BB6C-33697B418434}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -103,36 +123,6 @@ Global
 		{C91C065B-A821-4890-9F31-F9E245D804D1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{C91C065B-A821-4890-9F31-F9E245D804D1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{C91C065B-A821-4890-9F31-F9E245D804D1}.Release|x86.ActiveCfg = Release|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{4604C450-EBF8-4A7F-BD3A-A24655C41FA4}.Release|x86.ActiveCfg = Release|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Any CPU.Build.0 = Release|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{246F7AEC-9429-4FBB-8747-92A3F025C711}.Release|x86.ActiveCfg = Release|Any CPU
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|Mixed Platforms.Build.0 = Debug|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|x86.ActiveCfg = Debug|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Debug|x86.Build.0 = Debug|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Any CPU.ActiveCfg = Release|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|Mixed Platforms.Build.0 = Release|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|x86.ActiveCfg = Release|x86
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86}.Release|x86.Build.0 = Release|x86
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -143,13 +133,23 @@ Global
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{CCDE9AD7-3822-4B0B-AA19-DF6698A85D3D}.Release|x86.ActiveCfg = Release|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{E832A82B-2302-4113-83E3-261446E22C87}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{0D2A13E6-A092-402E-B8FE-035F3A620B86} = {840281A8-8870-417F-9B24-ED0E866608A2}
 		{486087C6-E95B-4FE2-8263-7B6B2DF81888} = {840281A8-8870-417F-9B24-ED0E866608A2}
 		{E832A82B-2302-4113-83E3-261446E22C87} = {840281A8-8870-417F-9B24-ED0E866608A2}
-		{0D2A13E6-A092-402E-B8FE-035F3A620B86} = {840281A8-8870-417F-9B24-ED0E866608A2}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
...S11.

Hopefully, you can use these simple changes -- this removes support for MVC2 as requested in Issue #73
