### PR TITLE
OPTIONS verb

### DIFF
--- a/src/AttributeRouting.Specs/Features/StandardUsage.feature
+++ b/src/AttributeRouting.Specs/Features/StandardUsage.feature
@@ -9,14 +9,18 @@ Scenario Outline: Generating routes for an action method
 	 And the default for "action" is "<action>"
 	 And the namespace is "AttributeRouting.Specs.Subjects"
 	Examples:
-		| method | action    | url                   |
-		| GET    | Index     | Index                 |
-		| HEAD   | Index     | Index                 |
-		| POST   | Create    | Create                |
-		| PUT    | Update    | Update/{id}           |
-		| DELETE | Destroy   | Destroy/{id}          |
-		| GET    | Wildcards | Wildcards/{*pathInfo} |
-		|        | AnyVerb   | AnyVerb               |
+		| method  | action    | url                   |
+		| GET     | Index     | Index                 |
+		| HEAD    | Index     | Index                 |
+		| OPTIONS | Index     | Index                 |
+		| POST    | Create    | Create                |
+		| OPTIONS | Create    | Create                |
+		| PUT     | Update    | Update/{id}           |
+		| OPTIONS | Update    | Update/{id}           |
+		| DELETE  | Destroy   | Destroy/{id}          |
+		| OPTIONS | Destroy   | Destroy/{id}          |
+		| GET     | Wildcards | Wildcards/{*pathInfo} |
+		|         | AnyVerb   | AnyVerb               |
 
 Scenario Outline: Generating routes for an API controller
 	Given I have registered the routes for the HttpStandardUsageController
@@ -28,11 +32,15 @@ Scenario Outline: Generating routes for an API controller
 	 And the namespace is "AttributeRouting.Specs.Subjects.Http"
 	
 	Examples:
-		| method | action    | url                       |
-		| GET    | Get       | api                       |
-		| HEAD   | Get       | api                       |
-		| POST   | Post      | api                       |
-		| PUT    | Put       | api/{id}                  |
-		| DELETE | Delete    | api/{id}                  |
-		| GET    | Wildcards | api/Wildcards/{*pathInfo} |
-		|        | AnyVerb   | api/AnyVerb               |
+		| method  | action    | url                       |
+		| GET     | Get       | api                       |
+		| HEAD    | Get       | api                       |
+		| OPTIONS | Get       | api                       |
+		| POST    | Post      | api                       |
+		| OPTIONS | Post      | api                       |
+		| PUT     | Put       | api/{id}                  |
+		| OPTIONS | Put       | api/{id}                  |
+		| DELETE  | Delete    | api/{id}                  |
+		| OPTIONS | Delete    | api/{id}                  |
+		| GET     | Wildcards | api/Wildcards/{*pathInfo} |
+		|         | AnyVerb   | api/AnyVerb               |

--- a/src/AttributeRouting.Web.Http/DELETEAttribute.cs
+++ b/src/AttributeRouting.Web.Http/DELETEAttribute.cs
@@ -11,6 +11,6 @@ namespace AttributeRouting.Web.Http
         /// Specify a route for an action constrained to requests providing an httpMethod value of DELETE.
         /// </summary>
         /// <param name="routeUrl">The url that is associated with this action</param>
-        public DELETEAttribute(string routeUrl) : base(routeUrl, HttpMethod.Delete) {}
+		public DELETEAttribute(string routeUrl) : base(routeUrl, HttpMethod.Delete, HttpMethod.Options) { }
     }
 }

--- a/src/AttributeRouting.Web.Http/GETAttribute.cs
+++ b/src/AttributeRouting.Web.Http/GETAttribute.cs
@@ -11,6 +11,6 @@ namespace AttributeRouting.Web.Http
         /// Specify a route for an action constrained to requests providing an httpMethod value of GET.
         /// </summary>
         /// <param name="routeUrl">The url that is associated with this action</param>
-        public GETAttribute(string routeUrl) : base(routeUrl, HttpMethod.Get, HttpMethod.Head) {}
+        public GETAttribute(string routeUrl) : base(routeUrl, HttpMethod.Get, HttpMethod.Head, HttpMethod.Options) {}
     }
 }

--- a/src/AttributeRouting.Web.Http/POSTAttribute.cs
+++ b/src/AttributeRouting.Web.Http/POSTAttribute.cs
@@ -11,6 +11,6 @@ namespace AttributeRouting.Web.Http
         /// Specify a route for an action constrained to requests providing an httpMethod value of POST.
         /// </summary>
         /// <param name="routeUrl">The url that is associated with this action</param>
-        public POSTAttribute(string routeUrl) : base(routeUrl, HttpMethod.Post) {}
+		public POSTAttribute(string routeUrl) : base(routeUrl, HttpMethod.Post, HttpMethod.Options) { }
     }
 }

--- a/src/AttributeRouting.Web.Http/PUTAttribute.cs
+++ b/src/AttributeRouting.Web.Http/PUTAttribute.cs
@@ -11,6 +11,6 @@ namespace AttributeRouting.Web.Http
         /// Specify a route for an action constrained to requests providing an httpMethod value of PUT.
         /// </summary>
         /// <param name="routeUrl">The url that is associated with this action</param>
-        public PUTAttribute(string routeUrl) : base(routeUrl, HttpMethod.Put) {}
+		public PUTAttribute(string routeUrl) : base(routeUrl, HttpMethod.Put, HttpMethod.Options) { }
     }
 }


### PR DESCRIPTION
Hey, I don't know if this is the right way to implement it, but it would be really handy to allow OPTIONS on a resource (just as you do with GET and HEAD). 

It does mean the consumer should implement their own OptionsActionFilter to modify the response, but this isn't too different from HEAD (as to be HTTP compliant the user should clear the response body, ideally done via an ActionFilter too).

The tests didn't ever seem to fail for my change when I added the new verb. Not sure if I've missed something.
