### PR TITLE
Fixed issue with route cast in LogRoutesHandler

### DIFF
--- a/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
+++ b/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
@@ -59,7 +59,7 @@ namespace AttributeRouting.Web.Logging
 
         private static IEnumerable<object> GetRouteInfo()
         {
-            return from r in RouteTable.Routes.Cast<Route>()
+            return from r in RouteTable.Routes.Where(x => x is Route).Cast<Route>()
                    let routeInfo = AttributeRouteInfo.GetRouteInfo(r.Url, r.Defaults, r.Constraints, r.DataTokens)
                    select new
                    {


### PR DESCRIPTION
The GetRouteInfo method was assuming that all routes in the RouteTable are of type Route, some projects make up their own routes using RouteBase such as N2CMS which then breaks the recourses.axd view.

I've just put in a check to make sure it is a Route before the cast.
