### PR TITLE
Changed to Use OfType instead of "Where is Cast"

### DIFF
--- a/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
+++ b/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
@@ -59,7 +59,7 @@ namespace AttributeRouting.Web.Logging
 
         private static IEnumerable<object> GetRouteInfo()
         {
-            return from r in RouteTable.Routes.Where(x => x is Route).Cast<Route>()
+            return from r in RouteTable.Routes.OfType<Route>()
                    let routeInfo = AttributeRouteInfo.GetRouteInfo(r.Url, r.Defaults, r.Constraints, r.DataTokens)
                    select new
                    {


### PR DESCRIPTION
While researching something completely different I came across this code and thought I could help.

Prior to the change the code was checking the type with `Where(x => x is Route)` then casting using `Cast<Route>()`. Using `OfType<Route>()` is more concise and has the potential to be more efficient, though having just checked it isn't since `OfType<T>` is implemented like this:

``` c#
foreach (object obj in source) {
    if (obj is TResult) yield return (TResult)obj;
}
```

Ultimately the function of the code is completely unchanged, I think it is worth implementing as it marginally simplifies it.
