### PR TITLE
iOpenCurly =/= i

### DIFF
--- a/src/AttributeRouting/Framework/RouteBuilder.cs
+++ b/src/AttributeRouting/Framework/RouteBuilder.cs
@@ -422,7 +422,7 @@ namespace AttributeRouting.Framework
                     {
                         // If we find an inner open curly (due to inner regex patterns), 
                         // then fast-forward beyond it.
-                        i = urlSegment.IndexOf('}', iOpenCurly);                        
+                        i = urlSegment.IndexOf('}', i);                        
                     }
 
                     i++;


### PR DESCRIPTION
The loop over URL sections was "searching for" regex closing curly braces from the section position, as opposed to the current position, which I figured was quite probably a mistake.
