### PR TITLE
Updated ThreeSection Subdomain parser to look for an IP Address

### DIFF
--- a/src/AttributeRouting.Specs/Tests/Subdomains/AttributeRouteTests.cs
+++ b/src/AttributeRouting.Specs/Tests/Subdomains/AttributeRouteTests.cs
@@ -93,5 +93,51 @@ namespace AttributeRouting.Specs.Tests.Subdomains
 
             Assert.That(data, Is.Not.Null);
         }
+
+        [Test]
+        public void Route_is_matched_if_subdomain_is_not_mapped_and_parsed_subdomain_is_an_IP_address()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+
+            const string host = "127.0.0.1";
+            var httpContextMock = MockBuilder.BuildMockHttpContext(r =>
+            {
+                r.SetupGet(x => x.Url).Returns(new Uri("http://" + host, UriKind.Absolute));
+                r.SetupGet(x => x.Headers).Returns(new NameValueCollection { { "host", host } });
+            });
+
+            var route = routes.First();
+            var data = route.GetRouteData(httpContextMock.Object);
+            Assert.That(data, Is.Not.Null);
+        }
+
+        [Test]
+        public void Route_is_matched_if_subdomain_is_not_mapped_and_parsed_subdomain_is_an_IP_address_with_port()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+
+            const string host = "127.0.0.1:81";
+            var httpContextMock = MockBuilder.BuildMockHttpContext(r =>
+            {
+                r.SetupGet(x => x.Url).Returns(new Uri("http://" + host, UriKind.Absolute));
+                r.SetupGet(x => x.Headers).Returns(new NameValueCollection { { "host", host } });
+            });
+
+            var route = routes.First();
+            var data = route.GetRouteData(httpContextMock.Object);
+            Assert.That(data, Is.Not.Null);
+        }
     }
 }

--- a/src/AttributeRouting/Framework/SubdomainParsers.cs
+++ b/src/AttributeRouting/Framework/SubdomainParsers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 
 namespace AttributeRouting.Framework
 {
@@ -20,6 +21,15 @@ namespace AttributeRouting.Framework
         {
             return host =>
             {
+                IPAddress ip;
+                if (host.Contains(":"))
+                {
+                    host = host.Substring(0, host.IndexOf(":", StringComparison.Ordinal));
+                }
+                if (IPAddress.TryParse(host, out ip))
+                {
+                    return null;
+                }
                 var sections = host.Split('.');
                 return sections.Length < 3
                            ? null


### PR DESCRIPTION
Currently AR looks for multiple "."s to determine if the request is to a sub-domain or not. But if you navigate to the site via an IP it incorrectly identifies the sub-domain. i.e. you go to your site at http://127.0.0.1:81/ the sub-domain would be "127.0".

Updated the ThreeSection Subdomain parser to test the host for being an IP address and returns null if it is. Tests have been added for IP and IP w/Port.
