### PR TITLE
Fix AttributeRouting.Web version reference

### DIFF
--- a/src/AttributeRouting.Tests.Web/Web.config
+++ b/src/AttributeRouting.Tests.Web/Web.config
@@ -49,14 +49,14 @@
       </namespaces>
     </pages>
     <httpHandlers>
-      <add path="routes.axd" verb="*" type="AttributeRouting.Web.Logging.LogRoutesHandler, AttributeRouting.Web, Version=1.0.0.0, Culture=neutral" />
+      <add path="routes.axd" verb="*" type="AttributeRouting.Web.Logging.LogRoutesHandler, AttributeRouting.Web" />
     </httpHandlers>
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
     <modules runAllManagedModulesForAllRequests="true" />
     <handlers>
-      <add name="AttributeRouting" path="routes.axd" verb="*" type="AttributeRouting.Web.Logging.LogRoutesHandler, AttributeRouting.Web, Version=1.0.0.0, Culture=neutral" />
+      <add name="AttributeRouting" path="routes.axd" verb="*" type="AttributeRouting.Web.Logging.LogRoutesHandler, AttributeRouting.Web" />
       <remove name="ExtensionlessUrlHandler-ISAPI-4.0_32bit" />
       <remove name="ExtensionlessUrlHandler-ISAPI-4.0_64bit" />
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />


### PR DESCRIPTION
Routes.axd handler had specific version reference which causes an assembly binding error.
