### PR TITLE
Added UrlHelperExtensions

### DIFF
--- a/src/AttributeRouting.Specs/AttributeRouting.Specs.csproj
+++ b/src/AttributeRouting.Specs/AttributeRouting.Specs.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Subjects\SubdomainControllers.cs" />
     <Compile Include="Subjects\LocalizationControllers.cs" />
     <Compile Include="Subjects\TrailingSlashesController.cs" />
+    <Compile Include="Tests\Extensions\UrlHelperExtensionTests.cs" />
     <Compile Include="Tests\Localization\AttributeRouteTests.cs" />
     <Compile Include="Tests\TrailingSlashes\AttributeRouteTests.cs" />
     <Compile Include="Tests\BugFixTests.cs" />

--- a/src/AttributeRouting.Specs/Tests/Extensions/UrlHelperExtensionTests.cs
+++ b/src/AttributeRouting.Specs/Tests/Extensions/UrlHelperExtensionTests.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Specialized;
+using System.Web;
+using System.Web.Mvc;
+using System.Web.Routing;
+using AttributeRouting.Specs.Subjects;
+using AttributeRouting.Web.Mvc;
+using AttributeRouting.Web.Mvc.Extensions;
+using Moq;
+using NUnit.Framework;
+
+namespace AttributeRouting.Specs.Tests.Extensions
+{
+    public class UrlHelperExtensionTests
+    {
+        private UrlHelper GetUrlHelper(RouteCollection routes, string host, string schema = "http")
+        {
+            Mock<HttpContextBase> httpContextMock = MockBuilder.BuildMockHttpContext(r =>
+            {
+                r.SetupGet(x => x.Url).Returns(new Uri(schema + "://" + host, UriKind.Absolute));
+                r.SetupGet(x => x.Headers).Returns(new NameValueCollection { { "host", host } });
+            });
+
+            return new UrlHelper(new RequestContext(httpContextMock.Object, new RouteData()), routes);
+        }
+
+        [Test]
+        public void Local_Host_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "localhost");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.localhost/", path);
+        }
+
+
+        [Test]
+        public void Top_Level_Domain_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.example.com/", path);
+        }
+
+        [Test]
+        public void Second_Level_Domain_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "example.co.uk");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.example.co.uk/", path);
+        }
+
+        [Test]
+        public void Top_Level_Domain_With_Subdomain_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<SubdomainWithAreaUrlController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+            var helper = GetUrlHelper(routes, "private.example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.example.com/", path);
+        }
+
+        [Test]
+        public void Second_Level_Domain_With_Subdomain_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<SubdomainWithAreaUrlController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+            var helper = GetUrlHelper(routes, "private.example.co.ok");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.example.co.ok/", path);
+        }
+
+        [Test]
+        public void Current_Subdomain_Action_To_Same_Subdomain_Will_Only_Be_The_Relative_Url()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "users.example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("/", path);
+        }
+
+        [Test]
+        public void Current_Subdomain_Action_To_No_Subdomain_And_Default_Subdomain_Will_Return_Full_Url()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+            var helper = GetUrlHelper(routes, "users.example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("AnyVerb", "StandardUsage");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://www.example.com/AnyVerb", path);
+        }
+
+        [Test]
+        public void Current_Subdomain_Action_To_No_Subdomain_And_Custom_Default_Subdomain_Will_Return_Full_Url()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+                config.DefaultSubdomain = "xyz";
+            });
+            var helper = GetUrlHelper(routes, "users.example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("AnyVerb", "StandardUsage");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://xyz.example.com/AnyVerb", path);
+        }
+
+        [Test]
+        public void Current_Subdomain_Action_To_No_Subdomain_And_No_Default_Subdomain_Will_Return_Full_Url()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+                config.DefaultSubdomain = "";
+            });
+            var helper = GetUrlHelper(routes, "users.example.com");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("AnyVerb", "StandardUsage");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://example.com/AnyVerb", path);
+        }
+
+        [Test]
+        public void Local_Host_With_Subdomain_Action_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<SubdomainWithAreaUrlController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+            var helper = GetUrlHelper(routes, "private.localhost");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", "Users");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.localhost/", path);
+        }
+
+
+        [Test]
+        public void Local_Host_With_Subdomain_Action_To_Non_Area_Method_Will_Return_Full_Url_Without_Default_Subdomain()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config =>
+            {
+                config.AddRoutesFromController<StandardUsageController>();
+                config.AddRoutesFromController<SubdomainController>();
+            });
+            var helper = GetUrlHelper(routes, "users.localhost");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "StandardUsage");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://localhost/", path);
+        }
+
+
+        [Test]
+        public void HTTP_URL_Will_Change_To_HTTPS()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "localhost");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", new {area = "Users"}, "https");
+            Console.WriteLine(path);
+            Assert.AreEqual("https://users.localhost/", path);
+        }
+
+        [Test]
+        public void HTTPS_URL_Will_Change_To_HTTP()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "localhost", "https");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", new { area = "Users" }, "http");
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.localhost/", path);
+        }
+
+        [Test]
+        public void Host_With_Port_Will_Have_A_Subdomain_Prepended()
+        {
+            var routes = RouteTable.Routes;
+            routes.Clear();
+            routes.MapAttributeRoutes(config => config.AddRoutesFromController<SubdomainController>());
+            var helper = GetUrlHelper(routes, "example.com:81");
+            Assert.That(helper, Is.Not.Null);
+            var path = helper.SubdomainAction("Index", "Subdomain", new { area = "Users" });
+            Console.WriteLine(path);
+            Assert.AreEqual("http://users.example.com:81/", path);
+        }
+    }
+}

--- a/src/AttributeRouting.Tests.Web/Views/Web.config
+++ b/src/AttributeRouting.Tests.Web/Views/Web.config
@@ -16,6 +16,8 @@
         <add namespace="System.Web.Mvc.Ajax" />
         <add namespace="System.Web.Mvc.Html" />
         <add namespace="System.Web.Routing" />
+
+        <add namespace="AttributeRouting.Web.Mvc.Extensions" />
       </namespaces>
     </pages>
   </system.web.webPages.razor>

--- a/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
+++ b/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Constraints\InboundHttpMethodConstraint.cs" />
     <Compile Include="Constraints\OptionalRouteConstraintWrapper.cs" />
     <Compile Include="DELETEAttribute.cs" />
+    <Compile Include="Extensions\UrlHelperExtensions.cs" />
     <Compile Include="Framework\AttributeRoute.cs" />
     <Compile Include="Framework\Factories\AttributeRouteFactory.cs" />
     <Compile Include="Framework\Factories\RouteParameterFactory.cs" />

--- a/src/AttributeRouting.Web.Mvc/Extensions/UrlHelperExtensions.cs
+++ b/src/AttributeRouting.Web.Mvc/Extensions/UrlHelperExtensions.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Web.Mvc;
+using System.Web.Routing;
+using AttributeRouting.Framework;
+using AttributeRouting.Helpers;
+
+namespace AttributeRouting.Web.Mvc.Extensions
+{
+    public static class UrlHelperExtensions
+    {
+        public static string SubdomainAction(this UrlHelper urlHelper, string actionName,
+                                             RouteValueDictionary routeValues)
+        {
+            string baseUrl = GetDomainBase(urlHelper, null, actionName, null, routeValues);
+            return BuildUri(baseUrl, urlHelper.Action(actionName, routeValues));
+        }
+
+        public static string SubdomainAction(this UrlHelper urlHelper, string actionName, string controllerName,
+                                             string areaName = "")
+        {
+            var routeValues = new RouteValueDictionary {{"area", areaName}};
+            string baseUrl = GetDomainBase(urlHelper, null, actionName, controllerName, routeValues);
+            return BuildUri(baseUrl, urlHelper.Action(actionName, controllerName, routeValues));
+        }
+
+        public static string SubdomainAction(this UrlHelper urlHelper, string actionName, string controllerName,
+                                             object routeValues)
+        {
+            string baseUrl = GetDomainBase(urlHelper, null, actionName, controllerName,
+                                           new RouteValueDictionary(routeValues));
+            return BuildUri(baseUrl, urlHelper.Action(actionName, controllerName, routeValues));
+        }
+
+        public static string SubdomainAction(this UrlHelper urlHelper, string actionName, string controllerName,
+                                             RouteValueDictionary routeValues)
+        {
+            string baseUrl = GetDomainBase(urlHelper, null, actionName, controllerName, routeValues);
+            return BuildUri(baseUrl, urlHelper.Action(actionName, controllerName, routeValues));
+        }
+
+        public static string SubdomainAction(this UrlHelper urlHelper, string actionName, string controllerName,
+                                             object routeValues, string protocol)
+        {
+            string baseUrl = GetDomainBase(urlHelper, null, actionName, controllerName,
+                                           new RouteValueDictionary(routeValues), protocol);
+            return BuildUri(baseUrl, urlHelper.Action(actionName, controllerName, routeValues));
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, object routeValues)
+        {
+            return SubdomainRouteUrl(urlHelper, null, routeValues);
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, RouteValueDictionary routeValues)
+        {
+            return SubdomainRouteUrl(urlHelper, null, routeValues);
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, string routeName)
+        {
+            return SubdomainRouteUrl(urlHelper, routeName, (object) null);
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, string routeName, object routeValues)
+        {
+            return SubdomainRouteUrl(urlHelper, routeName, routeValues, null);
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, string routeName,
+                                               RouteValueDictionary routeValues)
+        {
+            string baseUrl = GetDomainBase(urlHelper, routeName, null, null, routeValues);
+            return BuildUri(baseUrl, urlHelper.RouteUrl(routeName, routeValues));
+        }
+
+        public static string SubdomainRouteUrl(this UrlHelper urlHelper, string routeName, object routeValues,
+                                               string protocol)
+        {
+            var r = new RouteValueDictionary(routeValues);
+            string baseUrl = GetDomainBase(urlHelper, routeName, null, null, r, protocol);
+            return BuildUri(baseUrl, urlHelper.RouteUrl(routeName, routeValues));
+        }
+
+        /// <summary>
+        /// Gets the domain base url.
+        /// </summary>
+        /// <param name="urlHelper">The URL helper.</param>
+        /// <param name="routeName">Name of the route.</param>
+        /// <param name="actionName">Name of the action.</param>
+        /// <param name="controllerName">Name of the controller.</param>
+        /// <param name="routeValues">The route values.</param>
+        /// <param name="schema">The schema.</param>
+        /// <returns></returns>
+        private static string GetDomainBase(UrlHelper urlHelper, string routeName, string actionName,
+                                            string controllerName, RouteValueDictionary routeValues,
+                                            string schema = null)
+        {
+            //baseUrl is the return value which by default is an empty string
+            string baseUrl = string.Empty;
+
+            //just a shortcut variable so we don't have to have this the below line eight million times
+            Uri currentUrl = urlHelper.RequestContext.HttpContext.Request.Url;
+
+            //get the desired route using a copy of MS internal methods
+            RouteValueDictionary values = MergeRouteValues(actionName, controllerName, urlHelper.RequestContext.RouteData.Values, routeValues, true);
+            VirtualPathData virtualPathForArea = urlHelper.RouteCollection.GetVirtualPathForArea(urlHelper.RequestContext, routeName, values);
+            if (virtualPathForArea == null)
+            {
+                return baseUrl;
+            }
+
+            //if not a AttributeRoute or the current url is funny then nothing we can do so move on
+            var route = virtualPathForArea.Route as IAttributeRoute;
+            if (route != null && currentUrl != null && !string.IsNullOrWhiteSpace(currentUrl.OriginalString))
+            {
+                //get the current domain via the current Uri.
+                string host = currentUrl.GetLeftPart(UriPartial.Authority).Replace(currentUrl.GetLeftPart(UriPartial.Scheme), string.Empty);
+
+                IPAddress ip;
+                //if the port exists in the host remove it so that we don't run into trouble with the IPAddress parsing
+                if (host.Contains(":"))
+                {
+                    host = host.Substring(0, host.IndexOf(":", StringComparison.Ordinal));
+                }
+
+                //if an ip then no point in building a subdomain for it
+                if (IPAddress.TryParse(host, out ip))
+                {
+                    return string.Empty;
+                }
+
+                //save the current host for comparisons later
+                string currentHost = host;
+
+                //which protocol schema to use. i.e. http, https
+                string scheme = schema ?? currentUrl.Scheme;
+
+                //what is the current port. needed if non-standard
+                int port = currentUrl.Port;
+
+                //is the port a standard port?
+                bool useDefaultPort = port == 80 || port == 443;
+
+                //need the default subdomain incase we are going from one subdomain method to a non-subdomain method
+                string defaultSubdomain = string.Empty;
+                if (route.DataTokens.Any(x => x.Key.Equals("defaultSubdomain")))
+                {
+                    defaultSubdomain = route.DataTokens["defaultSubdomain"].ToString();
+                }
+
+                //if the host contains a dot we need to remove the subdomain if it is in the list of ones to remove
+                if (host.Contains("."))
+                {
+                    //get all registered subdomains
+                    List<string> subdomains =
+                        urlHelper.RouteCollection.Where(x => x is IAttributeRoute)
+                                 .Cast<IAttributeRoute>()
+                                 .Where(x => x.Subdomain.HasValue())
+                                 .Select(x => x.Subdomain)
+                                 .Distinct()
+                                 .ToList();
+
+                    //also add the default subdomain from the current route
+                    if (!string.IsNullOrWhiteSpace(defaultSubdomain) && !subdomains.Contains(defaultSubdomain))
+                    {
+                        subdomains.Add(defaultSubdomain);
+                    }
+
+                    //strips subdomain information off of current (if matching a current one)
+                    string subDomainSection = host.Split('.')[0];
+                    foreach (
+                        string subdomain in
+                            subdomains.Where(
+                                subdomain =>
+                                subDomainSection.Equals(subdomain, StringComparison.InvariantCultureIgnoreCase)))
+                    {
+                        host = host.Replace(string.Format("{0}.", subdomain), string.Empty);
+                        break;
+                    }
+                }
+
+                //if not a subdomain then don't build the url. instead build it to the default subdomain
+                if (!string.IsNullOrWhiteSpace(route.Subdomain))
+                {
+                    //if host already starts with subdomain then skip building the url
+                    if (!currentHost.StartsWith(route.Subdomain))
+                    {
+                        baseUrl = string.Format("{0}://{1}.{2}", scheme, route.Subdomain, host);
+                    }
+                }
+                else
+                {
+                    //no subdomain so we should add the default subdomain unless it is localhost 
+                    var gotoSubdomain = string.Empty;
+                    if (!host.Equals("localhost", StringComparison.InvariantCultureIgnoreCase) && !string.IsNullOrWhiteSpace(defaultSubdomain))
+                    {
+                        gotoSubdomain = string.Format("{0}.", defaultSubdomain);
+                    }
+                    baseUrl = string.Format("{0}://{1}{2}", scheme, gotoSubdomain, host);
+                }
+
+                //not using a standard port so if the baseurl has a value then append on the port
+                if (!string.IsNullOrWhiteSpace(baseUrl) && !useDefaultPort)
+                {
+                    baseUrl = string.Format("{0}:{1}", baseUrl, port);
+                }
+            }
+            return baseUrl;
+        }
+
+        private static string BuildUri(string baseUrl, string relativeUrl)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl) && string.IsNullOrWhiteSpace(relativeUrl))
+            {
+                return string.Empty;
+            }
+            if (string.IsNullOrWhiteSpace(baseUrl))
+            {
+                return relativeUrl;
+            }
+            if (string.IsNullOrWhiteSpace(relativeUrl))
+            {
+                return baseUrl;
+            }
+            if (!relativeUrl.StartsWith("/"))
+            {
+                relativeUrl = "/" + relativeUrl;
+            }
+            return string.Format("{0}{1}", baseUrl, relativeUrl);
+        }
+
+        public static RouteValueDictionary GetRouteValues(RouteValueDictionary routeValues)
+        {
+            return routeValues == null ? new RouteValueDictionary() : new RouteValueDictionary(routeValues);
+        }
+
+        public static RouteValueDictionary MergeRouteValues(string actionName, string controllerName,
+                                                            RouteValueDictionary implicitRouteValues,
+                                                            RouteValueDictionary routeValues,
+                                                            bool includeImplicitMvcValues)
+        {
+            var routeValueDictionary = new RouteValueDictionary();
+            if (includeImplicitMvcValues)
+            {
+                object obj;
+                if (implicitRouteValues != null && implicitRouteValues.TryGetValue("action", out obj))
+                {
+                    routeValueDictionary["action"] = obj;
+                }
+                if (implicitRouteValues != null && implicitRouteValues.TryGetValue("controller", out obj))
+                {
+                    routeValueDictionary["controller"] = obj;
+                }
+            }
+            if (routeValues != null)
+            {
+                foreach (var keyValuePair in GetRouteValues(routeValues))
+                {
+                    routeValueDictionary[keyValuePair.Key] = keyValuePair.Value;
+                }
+            }
+            if (actionName != null)
+            {
+                routeValueDictionary["action"] = actionName;
+            }
+            if (controllerName != null)
+            {
+                routeValueDictionary["controller"] = controllerName;
+            }
+            return routeValueDictionary;
+        }
+    }
+}

--- a/src/AttributeRouting/Framework/RouteBuilder.cs
+++ b/src/AttributeRouting/Framework/RouteBuilder.cs
@@ -351,7 +351,8 @@ namespace AttributeRouting.Framework
             var dataTokens = new Dictionary<string, object>
             {
                 { "namespaces", new[] { routeSpec.ControllerType.Namespace } },
-                { "actionMethod", routeSpec.ActionMethod }
+                { "actionMethod", routeSpec.ActionMethod },
+                { "defaultSubdomain", _configuration.DefaultSubdomain}
             };
 
             if (routeSpec.HttpMethods.Any())


### PR DESCRIPTION
Added UrlHelperExtensions to AttributeRouting.Web.Mvc.Extensions that helps create links to a subdomain related action. The main work of the class is the GetDomainBase method which builds the host part of the uri. This method is well commented with my thoughts.

Also added UrlHelperExtensionTests to AttributeRouting.Specs.Tests.Extensions to test the provided solution. More testing will be needed as I didn't test the RouteUrl methods as I don't use them.
