### PR TITLE
Fix for IndexOutOfRangeException when url param is missing closing brace

### DIFF
--- a/src/AttributeRouting/Framework/RouteBuilder.cs
+++ b/src/AttributeRouting/Framework/RouteBuilder.cs
@@ -581,7 +581,7 @@ namespace AttributeRouting.Framework
                 // Fast-forward past url param contents
                 if (c == '{')
                 {
-                    while (url[i] != '}' && i < length)
+                    while (i < length && url[i] != '}') //check length prior to accessing the character
                     {
                         i++;
                     }


### PR DESCRIPTION
If you have a controller with a route like "/something/{id" you will get a IndexOutOfRangeException which is not very helpful in determining the cause of the issue. 

With this fix if you forget the closing brace you will get a ArgumentException with the following message "There is an incomplete parameter in this path segment: '{id'. Check that each '{' character has a matching '}' character." which is thrown by the  System.Web.Http.Routing.HttpRouteParser
