### PR TITLE
Fix #225 - add PATCH attribute.

### DIFF
--- a/src/AttributeRouting.Specs/Subjects/Http/HttpStandardUsageController.cs
+++ b/src/AttributeRouting.Specs/Subjects/Http/HttpStandardUsageController.cs
@@ -29,6 +29,12 @@ namespace AttributeRouting.Specs.Subjects.Http
             return "";
         }
 
+        [PATCH("api/{id}")]
+        public string Patch()
+        {
+            return "";
+        }
+
         [GET("api/Wildcards/{*pathInfo}")]
         public string Wildcards()
         {

--- a/src/AttributeRouting.Specs/Subjects/StandardUsageController.cs
+++ b/src/AttributeRouting.Specs/Subjects/StandardUsageController.cs
@@ -30,6 +30,12 @@ namespace AttributeRouting.Specs.Subjects
             return Content("");
         }
 
+        [PATCH("PartialUpdate/{id}")]
+        public ActionResult PartialUpdate()
+        {
+            return Content("");
+        }
+
         [GET("Wildcards/{*pathInfo}")]
         public ActionResult Wildcards()
         {
@@ -62,6 +68,12 @@ namespace AttributeRouting.Specs.Subjects
 
         [DELETE]
         public ActionResult DeleteDefault()
+        {
+            return Content("");
+        }
+
+        [PATCH]
+        public ActionResult PatchDefault()
         {
             return Content("");
         }

--- a/src/AttributeRouting.Specs/Tests/BugFixTests.cs
+++ b/src/AttributeRouting.Specs/Tests/BugFixTests.cs
@@ -169,7 +169,7 @@ namespace AttributeRouting.Specs.Tests
                     x.AddRoutesFromController<HttpStandardUsageController>();
                 });
 
-            Assert.AreEqual(6, inMemoryConfig.Routes.Count);
+            Assert.AreEqual(7, inMemoryConfig.Routes.Count);
             Assert.True(inMemoryConfig.Routes.All(x => x.Constraints.All(c => c.Value.GetType() == typeof(InboundHttpMethodConstraint))));
         }
 
@@ -181,7 +181,7 @@ namespace AttributeRouting.Specs.Tests
 
             inMemoryConfig.Routes.MapHttpAttributeRoutes(x => x.AddRoutesFromController<HttpStandardUsageController>());
 
-            Assert.AreEqual(6, inMemoryConfig.Routes.Count);
+            Assert.AreEqual(7, inMemoryConfig.Routes.Count);
             Assert.True(inMemoryConfig.Routes.All(x => x.Constraints.All(c => c.Value.GetType() == typeof(Web.Http.WebHost.Constraints.InboundHttpMethodConstraint))));
         }
 

--- a/src/AttributeRouting.Tests.Web/Areas/Api/Controllers/PlainController.cs
+++ b/src/AttributeRouting.Tests.Web/Areas/Api/Controllers/PlainController.cs
@@ -37,5 +37,11 @@ namespace AttributeRouting.Tests.Web.Areas.Api.Controllers
         public void Delete(int id)
         {
         }
+
+        // PATCH /api/plain/5
+        [PATCH("{id}")]
+        public void Patch()
+        {
+        }
     }
 }

--- a/src/AttributeRouting.Web.Http/AttributeRouting.Web.Http.csproj
+++ b/src/AttributeRouting.Web.Http/AttributeRouting.Web.Http.csproj
@@ -94,6 +94,7 @@
     <Compile Include="GETAttribute.cs" />
     <Compile Include="HttpConfiguration.cs" />
     <Compile Include="HttpConfigurationBase.cs" />
+    <Compile Include="PATCHAttribute.cs" />
     <Compile Include="POSTAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PUTAttribute.cs" />

--- a/src/AttributeRouting.Web.Http/PATCHAttribute.cs
+++ b/src/AttributeRouting.Web.Http/PATCHAttribute.cs
@@ -1,0 +1,16 @@
+using System.Net.Http;
+
+namespace AttributeRouting.Web.Http
+{
+    /// <summary>
+    /// Defines a route for an action constrained to requests providing an httpMethod value of PATCH.
+    /// </summary>
+    public class PATCHAttribute : HttpRouteAttribute
+    {
+        /// <summary>
+        /// Specify a route for a PATCH request.
+        /// </summary>
+        /// <param name="routeUrl">The url that is associated with this action</param>
+        public PATCHAttribute(string routeUrl) : base(routeUrl, new HttpMethod("PATCH")) { }
+    }
+}

--- a/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
+++ b/src/AttributeRouting.Web.Mvc/AttributeRouting.Web.Mvc.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Framework\RouteParameterFactory.cs" />
     <Compile Include="Framework\RouteConstraintFactory.cs" />
     <Compile Include="GETAttribute.cs" />
+    <Compile Include="PATCHAttribute.cs" />
     <Compile Include="POSTAttribute.cs" />
     <Compile Include="PUTAttribute.cs" />
     <Compile Include="RouteAttribute.cs" />

--- a/src/AttributeRouting.Web.Mvc/PATCHAttribute.cs
+++ b/src/AttributeRouting.Web.Mvc/PATCHAttribute.cs
@@ -1,0 +1,20 @@
+namespace AttributeRouting.Web.Mvc
+{
+    /// <summary>
+    /// Defines a PATCH route for an action in Mvc Controllers.
+    /// </summary>
+    public class PATCHAttribute : RouteAttribute
+    {
+        /// <summary>
+        /// Specify a route for PATCH request.
+        /// The route URL will be the name of the action.
+        /// </summary>
+        public PATCHAttribute() : base("PATCH") { }
+
+        /// <summary>
+        /// Specify a route for PATCH request.
+        /// </summary>
+        /// <param name="routeUrl">The url that is associated with this action</param>
+        public PATCHAttribute(string routeUrl) : base(routeUrl, "PATCH") { }
+    }
+}

--- a/src/AttributeRouting.Web.Mvc/RouteAttribute.cs
+++ b/src/AttributeRouting.Web.Mvc/RouteAttribute.cs
@@ -42,9 +42,19 @@ namespace AttributeRouting.Web.Mvc
         /// </summary>
         /// <param name="allowedMethods">The httpMethods against which to constrain the route</param>
         public RouteAttribute(params HttpVerbs[] allowedMethods)
+            : this(allowedMethods.Select(m => m.ToString()).ToArray())
+        {
+        }
+
+        /// <summary>
+        /// Specify the route information for an action.
+        /// The route URL will be the name of the action.
+        /// </summary>
+        /// <param name="allowedMethods">The httpMethods against which to constrain the route</param>
+        public RouteAttribute(params string[] allowedMethods)
             : this()
         {
-            HttpMethods = allowedMethods.Select(m => m.ToString().ToUpperInvariant()).ToArray();
+            HttpMethods = allowedMethods.Select(m => m.ToUpperInvariant()).ToArray();
         }
 
         /// <summary>
@@ -53,9 +63,19 @@ namespace AttributeRouting.Web.Mvc
         /// <param name="routeUrl">The url that is associated with this action</param>
         /// <param name="allowedMethods">The httpMethods against which to constrain the route</param>
         public RouteAttribute(string routeUrl, params HttpVerbs[] allowedMethods)
+            : this(routeUrl, allowedMethods.Select(m => m.ToString()).ToArray())
+        {
+        }
+
+        /// <summary>
+        /// Specify the route information for an action.
+        /// </summary>
+        /// <param name="routeUrl">The url that is associated with this action</param>
+        /// <param name="allowedMethods">The httpMethods against which to constrain the route</param>
+        public RouteAttribute(string routeUrl, params string[] allowedMethods)
             : this(routeUrl)
         {
-            HttpMethods = allowedMethods.Select(m => m.ToString().ToUpperInvariant()).ToArray();
+            HttpMethods = allowedMethods.Select(m => m.ToUpperInvariant()).ToArray();
         }
 
         public string RouteUrl { get; private set; }


### PR DESCRIPTION
Made a quick change to the `RouteAttribute` to support arbitrary HTTP verbs. Added PATCH for both MVC and WebApi.

I'm not sure how you go about testing these attributes, but I tried to follow the convention about defining the common "API".

I can probably add HEAD and OPTIONS attributes as well.
