### PR TITLE
RouteLoggingInfo: Don't crash if a null default is present

### DIFF
--- a/src/AttributeRouting/Logging/RouteLoggingInfo.cs
+++ b/src/AttributeRouting/Logging/RouteLoggingInfo.cs
@@ -40,7 +40,7 @@ namespace AttributeRouting.Logging
             
             foreach (var @default in allDefaults)
             {
-                var defaultValue = @default.Value.ToString();
+                var defaultValue = (@default.Value ?? string.Empty).ToString();
                 item.Defaults.Add(@default.Key, defaultValue);
             }
 


### PR DESCRIPTION
Area routes using T4MVC can sometimes have nulls in the defaults dictionary, causing the RouteLoggingInfo class to crash when it tries to iterate through the defaults.
