### PR TITLE
Fixes #267

### DIFF
--- a/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
+++ b/src/AttributeRouting.Web/Logging/LogRoutesHandler.cs
@@ -50,7 +50,7 @@ namespace AttributeRouting.Web.Logging
 
         public void ProcessRequest(HttpContext context)
         {
-            if (context.Request.IsLocal)
+            if (!context.Request.IsLocal)
             {
                 context.Response.StatusCode = 404;
                 return;


### PR DESCRIPTION
404 when request is not local. routes.axd should only be accessible in development.
