### PR TITLE
Fixing Issue with MVC 5 . On IIS the HttpRoute.GetRouteData is now be…

### DIFF
--- a/src/AttributeRouting/Framework/AttributeRouteVisitor.cs
+++ b/src/AttributeRouting/Framework/AttributeRouteVisitor.cs
@@ -222,7 +222,7 @@ namespace AttributeRouting.Framework
         public bool IsStaticLeftPartOfUrlMatched(string requestedPath)
         {
             // Compare the left part with the requested path
-            var comparableRequestedPath = requestedPath.TrimEnd('/');
+            var comparableRequestedPath = requestedPath.TrimEnd('/').TrimStart('/');
             return comparableRequestedPath.StartsWith(StaticLeftPartOfUrl, StringComparison.OrdinalIgnoreCase);
         }
 


### PR DESCRIPTION
…Fixing Issue with MVC 5 . On IIS the HttpRoute.GetRouteData is now being called without a leading / as well