### PR TITLE
Add link to doc page as HTML

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,4 +1,6 @@
-h2. Please refer to "attributerouting.net":http://attributerouting.net/ for documentation.
+h2. Please see "the documentation":https://github.com/mccalltd/AttributeRouting/blob/gh-pages/index.html rendered by "HTMLPreview":http://htmlpreview.github.io/ at "this URL":doc-preview.
+
+[doc-preview]http://htmlpreview.github.io/?https://github.com/mccalltd/AttributeRouting/blob/gh-pages/index.html
 
 *If you encounter any issues using this library, please log them in the "issue tracker":https://github.com//issues. Thanks.*
 


### PR DESCRIPTION
The domain of the previous project site seems to no longer be registered (or in control of the project maintainers). I added a link to the documentation from the GitHub Pages source rendered as HTML by the online tool [GitHub & BitBucket HTML Preview](http://htmlpreview.github.io/).

Unless the previous project site domain will be re-registered (or wrested back into control by the project maintainers), the reference to it should probably be removed entirely.